### PR TITLE
fix: Set default value for options parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function removeGlobalEvent(_ref5) {
 }
 
 exports.default = {
-    install: function install(Vue, options) {
+    install: function install(Vue, options = {}) {
         var idSubsProp = isCorrectCustomName('idSubs', options) || '$idSubs';
         var listenToProp = isCorrectCustomName('listenTo', options) || '$listenTo';
         var emitEventProp = isCorrectCustomName('emitEvent', options) || '$emitEvent';


### PR DESCRIPTION
When installing the plugin without passing any options (`Vue.use(HandySubs)`), I encountered this error:

```
Uncaught TypeError: Cannot read property 'idSubs' of undefined
  at isCorrectCustomName
```

The error doesn't occur when I pass empty options object: `Vue.use(HandySubs, {})`

This change should prevent the error from happening when no options are passed.